### PR TITLE
Update node-metamask version

### DIFF
--- a/packages/colony-starter-basic/package.json
+++ b/packages/colony-starter-basic/package.json
@@ -32,7 +32,7 @@
     "buffer": "^5.1.0",
     "ethers": "^3.0.17",
     "ipfs": "^0.29.2",
-    "node-metamask": "^1.1.0",
+    "node-metamask": "^1.1.1",
     "web3": "^1.0.0-beta.35"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6464,9 +6464,9 @@ node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
 
-node-metamask@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/node-metamask/-/node-metamask-1.1.0.tgz#c7b2e8a8f361860d97846f0adf9ec995bc47d6de"
+node-metamask@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/node-metamask/-/node-metamask-1.1.1.tgz#2353d229117538ae72eafc4f995157be20becf05"
   dependencies:
     express "^4.16.3"
     ws "^5.2.0"


### PR DESCRIPTION
## Description

Updates to latest version of `node-metamask`.

## Dependencies

**Updated Dependencies**:

```
"node-metamask": "^1.1.1",
```

## Resolves

#14