### PR TITLE
Add commander to package dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "chalk": "^2.4.1",
+    "commander": "^2.17.1",
     "ganache-cli": "^6.1.0",
     "lerna": "^3.0.0-rc.0",
     "trufflepig": "^1.0.4"


### PR DESCRIPTION
## Description

Add `commander` to package dependencies.

## Dependencies

```
"commander": "^2.17.1"
```

## Resolves

https://github.com/JoinColony/colonyStarter/issues/25
