### PR TITLE
Add colony-starter dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "chalk": "^2.4.1",
+    "fs-extra": "^7.0.0",
     "ganache-cli": "^6.1.0",
     "lerna": "^3.0.0-rc.0",
     "trufflepig": "^1.0.4"

--- a/packages/colony-starter/package.json
+++ b/packages/colony-starter/package.json
@@ -14,6 +14,10 @@
   },
   "dependencies": {
     "chalk": "^2.4.1",
-    "tar-pack": "^3.4.1"
+    "commander": "^2.17.1",
+    "cross-spawn": "^6.0.5",
+    "fs-extra": "^7.0.0",
+    "tar-pack": "^3.4.1",
+    "tmp": "^0.0.33"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1814,7 +1814,7 @@ commander@^2.11.0, commander@^2.15.0:
   version "2.17.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.0.tgz#9d07b25e2a6f198b76d8b756a0e8a9604a6a1a60"
 
-commander@^2.8.1:
+commander@^2.17.1, commander@^2.8.1:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
 
@@ -2057,7 +2057,7 @@ cross-spawn@^5.0.1:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^6.0.0:
+cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   dependencies:
@@ -3206,6 +3206,14 @@ fs-extra@^2.0.0, fs-extra@^2.1.2:
 fs-extra@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-6.0.1.tgz#8abc128f7946e310135ddc93b98bddb410e7a34b"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.0.tgz#8cc3f47ce07ef7b3593a11b9fb245f7e34c041d6"
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"


### PR DESCRIPTION
## Description

Adds required dependencies to the `colony-starter` package assuming the user installing the package has no prior dependencies globally installed.

## Other Changes

Adds `fs-extra` to root package.

## Dependencies

**Added Dependencies**:

_root_:

```
"fs-extra": "^7.0.0",
```

_colony-starter_:

```
"commander": "^2.17.1",
"cross-spawn": "^6.0.5",
"fs-extra": "^7.0.0",
"tmp": "^0.0.33"
```

## Resolves

#25
