### PR TITLE
Update networkLoader and colonyJS

### DIFF
--- a/packages/colony-starter-basic/package.json
+++ b/packages/colony-starter-basic/package.json
@@ -25,9 +25,9 @@
   },
   "dependencies": {
     "@colony/colony-js-adapter-ethers": "1.6.0",
-    "@colony/colony-js-client": "1.6.0",
+    "@colony/colony-js-client": "1.6.1",
     "@colony/colony-js-contract-loader-http": "1.5.4",
-    "@colony/colony-js-contract-loader-network": "1.0.3",
+    "@colony/colony-js-contract-loader-network": "1.6.1",
     "bn.js": "^4.11.8",
     "buffer": "^5.1.0",
     "ethers": "3.0.27",

--- a/packages/colony-starter-react/package.json
+++ b/packages/colony-starter-react/package.json
@@ -22,17 +22,17 @@
     "testURL": "http://localhost"
   },
   "dependencies": {
-    "@colony/colony-js-adapter-ethers": "1.5.3",
-    "@colony/colony-js-client": "1.5.3",
-    "@colony/colony-js-contract-loader-http": "1.4.1",
-    "@colony/colony-js-contract-loader-network": "1.0.3",
+    "@colony/colony-js-adapter-ethers": "1.6.0",
+    "@colony/colony-js-client": "1.6.1",
+    "@colony/colony-js-contract-loader-http": "1.5.4",
+    "@colony/colony-js-contract-loader-network": "1.6.1",
     "bn.js": "^4.11.8",
     "buffer": "^5.1.0",
-    "ethers": "^3.0.17",
+    "ethers": "^3.0.27",
     "ipfs": "^0.29.2"
   },
   "devDependencies": {
-    "ganache-cli": "^6.1.0",
+    "ganache-cli": "^6.1.8",
     "jest": "^23.1.0",
     "trufflepig": "^1.0.4"
   }


### PR DESCRIPTION
## Description

This PR updates the network loader package and colonyJS. 

It also updates the react example in line with the basic example (Ganache, ethers).

**Updated Dependencies**:

* ganache-cli
* ethers
* @colony/colony-js-client
* @colony/colony-js-network-loader
