### PR TITLE
Fixed lapse in comments on transferring of funds

### DIFF
--- a/packages/colony-starter-basic/src/index.js
+++ b/packages/colony-starter-basic/src/index.js
@@ -140,7 +140,7 @@ const colonyStarterBasic = async () => {
 
   log('account[0] moveFundsBetweenPots:');
 
-  // Move funds to our task using the "moveFundsBetweenPots" example.
+  // Move funds to our domain using the "moveFundsBetweenPots" example.
   await moveFundsBetweenPots(
     state.colonyClient[0],          // colonyClient
     1,                              // fromPot


### PR DESCRIPTION
Seems like comments explaining movement of funds was copied from one place to another and in the first step where funds are being moved from colony to domain it's unclear why the funds are going to task if we have just created domain.

I'm proposing the fix to keep the logic clear for the reader :)