### PR TITLE
Update colony-js package versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,20 +45,18 @@ Move to your working directory and unpack the [colony-starter-basic](/packages/c
 colony-starter colony-starter-basic
 ```
 
+Alternatively, you can use [npx](https://www.npmjs.com/package/npx) and kickstart the [colony-starter-basic](/packages/colony-starter-basic) package in one line without having to globally install the [colony-starter](/packages/colony-starter) package:
+
+```
+npx -p @colony/colony-starter colony-starter colony-starter-basic
+```
+
 ### Step 3
 
 Move to your new project directory and checkout the [colony-starter-basic](/packages/colony-starter-basic) readme:
 
 ```
 cd colony-starter-basic
-```
-
-### 1-step install
-
-Alternatively, you can kickstart the [colony-starter-basic](/packages/colony-starter-basic) in one line without having to add the colony-starter global package by using [npx](https://www.npmjs.com/package/npx):
-
-```
-npx -p @colony/colony-starter colony-starter colony-starter-basic
 ```
 
 ## Starter Projects

--- a/docs/_Docs_LinuxSetup.md
+++ b/docs/_Docs_LinuxSetup.md
@@ -1,0 +1,57 @@
+---
+title: Linux Setup
+section: Docs
+order: 1
+---
+
+### Yarn Setup
+
+If you have not already done so, configure your bash shell to run globally installed yarn commands.
+
+#### Configure your bash shell
+
+Add the following to your `~/.bashrc` file:
+
+```
+export PATH="$PATH:$HOME/.config/yarn/global/node_modules/.bin"
+```
+
+#### Load your updated bash configuration
+
+Either start a new instance or load the updated configuration by running the following command:
+
+```
+source ~/.bashrc
+```
+
+### Docker Setup
+
+If you have not already completed the ["Post-installation steps for Linux"](https://docs.docker.com/install/linux/linux-postinstall/), you will need to perform the following steps to allow a non-root user to pull images from docker:
+
+#### Create the docker group
+
+```
+sudo groupadd docker
+```
+
+#### Add the current user to the docker group
+
+```
+sudo usermod -aG docker $USER
+```
+
+#### Ensure the new user membership is evaluated
+
+Log out and log back in so that your group membership is re-evaluated.
+
+- _If testing on a virtual machine, it may be necessary to restart the virtual machine for changes to take effect._
+
+- _On a desktop Linux environment such as X Windows, log out of your session completely and then log back in._
+
+#### Run the docker test command
+
+Download a test image and run it in a container to verify the current user is authorized to run docker commands.
+
+```
+docker run hello-world
+```

--- a/docs/_Docs_Overview.md
+++ b/docs/_Docs_Overview.md
@@ -34,6 +34,12 @@ Move to your working directory and unpack the [colony-starter-basic](http://docs
 colony-starter colony-starter-basic
 ```
 
+Alternatively, you can use [npx](https://www.npmjs.com/package/npx) and kickstart the [colony-starter-basic](http://docs.colony.io/colonystarter/packages-colony-starter-basic/) package in one line without having to globally add the `colony-starter` package:
+
+```
+npx -p @colony/colony-starter colony-starter colony-starter-basic
+```
+
 ### Step 3
 
 Move to your new project directory and checkout the [colony-starter-basic](http://docs.colony.io/colonystarter/packages-colony-starter-basic/) instructions:

--- a/docs/_Docs_Overview.md
+++ b/docs/_Docs_Overview.md
@@ -18,9 +18,11 @@ _Learn to build with Colony! Get a head start on your next project!_ colonyStart
 
 _You may find it helpful to use Node Version Manager (`nvm`) to manage Node versions._
 
+_If you are using Linux, check out the [Linux Setup](/colonystarter/docs-linux-setup/) page to ensure Yarn and Docker are set up accordingly._
+
 ### Step 1
 
-Globally install the [colony-starter](http://docs.colony.io/colonystarter/packages-colony-starter/) package:
+Globally install the [colony-starter](/colonystarter/packages-colony-starter/) package:
 
 ```
 yarn global add @colony/colony-starter
@@ -28,13 +30,13 @@ yarn global add @colony/colony-starter
 
 ### Step 2
 
-Move to your working directory and unpack the [colony-starter-basic](http://docs.colony.io/colonystarter/packages-colony-starter-basic/) package:
+Move to your working directory and unpack the [colony-starter-basic](/colonystarter/packages-colony-starter-basic/) package:
 
 ```
 colony-starter colony-starter-basic
 ```
 
-Alternatively, you can use [npx](https://www.npmjs.com/package/npx) and kickstart the [colony-starter-basic](http://docs.colony.io/colonystarter/packages-colony-starter-basic/) package in one line without having to globally add the `colony-starter` package:
+Alternatively, you can use [npx](https://www.npmjs.com/package/npx) and kickstart the [colony-starter-basic](/colonystarter/packages-colony-starter-basic/) package in one line without having to globally add the `colony-starter` package:
 
 ```
 npx -p @colony/colony-starter colony-starter colony-starter-basic
@@ -42,7 +44,7 @@ npx -p @colony/colony-starter colony-starter colony-starter-basic
 
 ### Step 3
 
-Move to your new project directory and checkout the [colony-starter-basic](http://docs.colony.io/colonystarter/packages-colony-starter-basic/) instructions:
+Move to your new project directory and checkout the [colony-starter-basic](/colonystarter/packages-colony-starter-basic/) instructions:
 
 ```
 cd colony-starter-basic

--- a/docs/_Packages_ColonyStarter.md
+++ b/docs/_Packages_ColonyStarter.md
@@ -16,7 +16,7 @@ The `colony-starter` package includes the global command script to install colon
 
 _You may find it helpful to use Node Version Manager (`nvm`) to manage Node versions._
 
-_If you are using Linux, check out the [Linux Setup](https://github.com/JoinColony/colonyStarter/blob/master/.github/LINUX_SETUP.md) page to ensure Yarn and Docker are set up accordingly._
+_If you are using Linux, check out the [Linux Setup](/colonystarter/docs-linux-setup/) page to ensure Yarn and Docker are set up accordingly._
 
 ## Installation
 

--- a/docs/_Packages_ColonyStarter.md
+++ b/docs/_Packages_ColonyStarter.md
@@ -33,3 +33,9 @@ Install the colonyStarter project of your choice.
 ```
 colony-starter [colony-starter-package]
 ```
+
+Alternatively, you can use [npx](https://www.npmjs.com/package/npx) and kickstart a package in one line without having to globally add the `colony-starter` package:
+
+```
+npx -p @colony/colony-starter colony-starter [colony-starter-package]
+```

--- a/docs/_Packages_ColonyStarterBasic.md
+++ b/docs/_Packages_ColonyStarterBasic.md
@@ -34,6 +34,12 @@ Install the `colony-starter-basic` package.
 colony-starter colony-starter-basic
 ```
 
+Alternatively, you can use [npx](https://www.npmjs.com/package/npx) and kickstart the `colony-starter-basic` package in one line without having to globally add the [colony-starter](http://docs.colony.io/colonystarter/packages-colony-starter/) package:
+
+```
+npx -p @colony/colony-starter colony-starter colony-starter-basic
+```
+
 ## Run Examples
 
 ### Start Network

--- a/docs/_Packages_ColonyStarterBasic.md
+++ b/docs/_Packages_ColonyStarterBasic.md
@@ -8,7 +8,7 @@ order: 1
 
 The `colony-starter-basic` package is a starter project that demonstrates how to use [colonyJS](https://github.com/JoinColony/colonyJS) (a JavaScript client for [colonyNetwork](https://github.com/JoinColony/colonyNetwork)). This project is set up to start a local test network using [Ganache](https://github.com/trufflesuite/ganache-cli) and then deploy the [colonyNetwork](https://github.com/JoinColony/colonyNetwork) contracts to the local test network using [Truffle](https://github.com/trufflesuite/truffle). This project also uses [TrufflePig](https://github.com/JoinColony/trufflepig) to find and read the deployed contracts during local development.
 
-This project includes example scripts also found in the [Get Started](https://joincolony.github.io/colonyjs/docs-get-started/) and [Task Lifecycle](https://docs.colony.io/colonyjs/docs-task-lifecycle/) pages of the [colonyJS Docs](https://docs.colony.io/colonyjs/docs-overview). In order to help you hit the ground running with your new project, this starter project includes all of the examples from the docs plus some, and it gives you the opportunity to execute and test those examples with a few simple commands.
+This project includes example scripts also found in the [Get Started](https://joincolony.github.io/colonyjs/docs-get-started/) and [Task Lifecycle](/colonyjs/docs-task-lifecycle/) pages of the [colonyJS Docs](/colonyjs/docs-overview). In order to help you hit the ground running with your new project, this starter project includes all of the examples from the docs plus some, and it gives you the opportunity to execute and test those examples with a few simple commands.
 
 ## Prerequisites
 
@@ -18,7 +18,7 @@ This project includes example scripts also found in the [Get Started](https://jo
 
 _You may find it helpful to use Node Version Manager (`nvm`) to manage Node versions._
 
-_If you are using Linux, check out the [Linux Setup](https://github.com/JoinColony/colonyStarter/blob/master/.github/LINUX_SETUP.md) page to ensure Yarn and Docker are set up accordingly._
+_If you are using Linux, check out the [Linux Setup](/colonystarter/docs-linux-setup/) page to ensure Yarn and Docker are set up accordingly._
 
 ## Installation
 
@@ -34,7 +34,7 @@ Install the `colony-starter-basic` package.
 colony-starter colony-starter-basic
 ```
 
-Alternatively, you can use [npx](https://www.npmjs.com/package/npx) and kickstart the `colony-starter-basic` package in one line without having to globally add the [colony-starter](http://docs.colony.io/colonystarter/packages-colony-starter/) package:
+Alternatively, you can use [npx](https://www.npmjs.com/package/npx) and kickstart the `colony-starter-basic` package in one line without having to globally add the [colony-starter](/colonystarter/packages-colony-starter/) package:
 
 ```
 npx -p @colony/colony-starter colony-starter colony-starter-basic

--- a/packages/colony-starter-basic/package.json
+++ b/packages/colony-starter-basic/package.json
@@ -24,9 +24,9 @@
     "testURL": "http://localhost"
   },
   "dependencies": {
-    "@colony/colony-js-adapter-ethers": "1.6.0",
-    "@colony/colony-js-client": "1.6.1",
-    "@colony/colony-js-contract-loader-http": "1.5.4",
+    "@colony/colony-js-adapter-ethers": "1.7.0",
+    "@colony/colony-js-client": "1.7.3",
+    "@colony/colony-js-contract-loader-http": "1.6.2",
     "@colony/colony-js-contract-loader-network": "1.6.2",
     "bn.js": "^4.11.8",
     "buffer": "^5.1.0",

--- a/packages/colony-starter-basic/src/examples/createToken.js
+++ b/packages/colony-starter-basic/src/examples/createToken.js
@@ -2,7 +2,9 @@
 const createToken = async (networkClient, name, symbol) => {
 
   // Create a new ERC20 token
-  const tokenAddress = await networkClient.createToken({ name, symbol });
+  const {
+    meta: { receipt: { contractAddress: tokenAddress } }
+  } = await networkClient.createToken.send({ name, symbol });
 
   // Check out the logs to see the token address
   console.log('Token Address: ' + tokenAddress);

--- a/packages/colony-starter-basic/src/examples/revealTaskWorkRating.js
+++ b/packages/colony-starter-basic/src/examples/revealTaskWorkRating.js
@@ -1,8 +1,11 @@
+// Import web3 library
+const web3 = require('web3');
+
 // An example using the revealTaskWorkRating method
 const revealTaskWorkRating = async (colonyClient, taskId, role, rating) => {
 
   // Set salt value
-  const salt = 'secret';
+  const salt = web3.utils.sha3('secret');
 
   // Set rating value
   const value = rating;

--- a/packages/colony-starter-basic/src/examples/submitTaskWorkRating.js
+++ b/packages/colony-starter-basic/src/examples/submitTaskWorkRating.js
@@ -1,8 +1,11 @@
+// Import web3 library
+const web3 = require('web3');
+
 // An example using the submitTaskWorkRating method
 const submitTaskWorkRating = async (colonyClient, taskId, role, rating) => {
 
   // Set salt value
-  const salt = 'secret';
+  const salt = web3.utils.sha3('secret');
 
   // Set rating value
   const value = rating;

--- a/packages/colony-starter/package.json
+++ b/packages/colony-starter/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0-beta.4",
   "description": "A global command for creating starter projects",
   "license": "MIT",
-  "engines": {
-    "node": "9.10"
-  },
   "publishConfig": {
     "access": "public"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,11 +26,28 @@
     babel-runtime "^6.26.0"
     ethers "^3.0.27"
 
+"@colony/colony-js-adapter-ethers@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@colony/colony-js-adapter-ethers/-/colony-js-adapter-ethers-1.7.0.tgz#5b34f61710ba8cb67e9a35780e7e3828594beecb"
+  dependencies:
+    "@colony/colony-js-adapter" "^1.7.0"
+    "@colony/colony-js-contract-loader" "^1.6.2"
+    "@colony/colony-js-utils" "^1.5.4"
+    babel-runtime "^6.26.0"
+    ethers "^3.0.27"
+
 "@colony/colony-js-adapter@^1.6.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@colony/colony-js-adapter/-/colony-js-adapter-1.6.0.tgz#b129d7e5179b2e02aefa8c3877bde9f7aff4ab87"
   dependencies:
     "@colony/colony-js-contract-loader" "^1.5.4"
+    bn.js "^4.11.6"
+
+"@colony/colony-js-adapter@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@colony/colony-js-adapter/-/colony-js-adapter-1.7.0.tgz#3f41781f4369dcec79b58df28c702542eeaa25a4"
+  dependencies:
+    "@colony/colony-js-contract-loader" "^1.6.2"
     bn.js "^4.11.6"
 
 "@colony/colony-js-client@1.6.1":
@@ -46,12 +63,41 @@
     bn.js "^4.11.6"
     web3-utils "^1.0.0-beta.34"
 
+"@colony/colony-js-client@1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@colony/colony-js-client/-/colony-js-client-1.7.3.tgz#0d63e771c099c135257dbd6361c8d620e28b2e16"
+  dependencies:
+    "@colony/colony-js-adapter" "^1.7.0"
+    "@colony/colony-js-contract-client" "^1.7.3"
+    "@colony/colony-js-contract-loader" "^1.6.2"
+    "@colony/colony-js-utils" "^1.5.4"
+    assert "^1.4.1"
+    babel-runtime "^6.26.0"
+    bn.js "^4.11.6"
+    isomorphic-fetch "^2.2.1"
+    web3-utils "^1.0.0-beta.34"
+
 "@colony/colony-js-contract-client@^1.6.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@colony/colony-js-contract-client/-/colony-js-contract-client-1.6.0.tgz#3675e857ebcbebecb6152c084a61e3b353745a0e"
   dependencies:
     "@colony/colony-js-adapter" "^1.6.0"
     "@colony/colony-js-contract-loader" "^1.5.4"
+    "@colony/colony-js-utils" "^1.5.4"
+    assert "^1.4.1"
+    babel-runtime "^6.26.0"
+    bn.js "^4.11.6"
+    bs58 "^4.0.1"
+    lodash.isequal "^4.5.0"
+    lodash.isplainobject "^4.0.6"
+    web3-utils "^1.0.0-beta.34"
+
+"@colony/colony-js-contract-client@^1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@colony/colony-js-contract-client/-/colony-js-contract-client-1.7.3.tgz#921671c3fa56b54c417552c03767f654a3f7b7d0"
+  dependencies:
+    "@colony/colony-js-adapter" "^1.7.0"
+    "@colony/colony-js-contract-loader" "^1.6.2"
     "@colony/colony-js-utils" "^1.5.4"
     assert "^1.4.1"
     babel-runtime "^6.26.0"
@@ -70,6 +116,15 @@
     babel-runtime "^6.26.0"
     isomorphic-fetch "^2.2.1"
 
+"@colony/colony-js-contract-loader-http@1.6.2":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@colony/colony-js-contract-loader-http/-/colony-js-contract-loader-http-1.6.2.tgz#bb861e1d1af3e7ed2dd4b0d367cfa267efd3dd1c"
+  dependencies:
+    "@colony/colony-js-contract-loader" "^1.6.2"
+    assert "^1.4.1"
+    babel-runtime "^6.26.0"
+    isomorphic-fetch "^2.2.1"
+
 "@colony/colony-js-contract-loader-network@1.6.2":
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/@colony/colony-js-contract-loader-network/-/colony-js-contract-loader-network-1.6.2.tgz#12b88484b1fa40e065d1f4295f14590483928e51"
@@ -81,6 +136,13 @@
 "@colony/colony-js-contract-loader@1.5.4", "@colony/colony-js-contract-loader@^1.5.4":
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@colony/colony-js-contract-loader/-/colony-js-contract-loader-1.5.4.tgz#4b43cf66671f2ea419490cc676b08619b28002f8"
+  dependencies:
+    assert "^1.4.1"
+    babel-runtime "^6.26.0"
+
+"@colony/colony-js-contract-loader@^1.6.2":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@colony/colony-js-contract-loader/-/colony-js-contract-loader-1.6.2.tgz#56de7572169c68d95ef561955ca7be55c1626137"
   dependencies:
     assert "^1.4.1"
     babel-runtime "^6.26.0"


### PR DESCRIPTION
## Description

Update to the latest colonyJS package versions and fix any breaking changes.

## Other Changes

- Convert salt strings to hashes before passing to `generateSecret`
- Update docs and refine readme with `npx` package install instructions
- Add linux setup docs page and fix hyperlinks between docs pages
- Remove required node version from `colony-starter` package

## Checklist

- [x] Update colonyJS packages (#40)
- [x] Update `createToken` method (#39)
- [x] Convert salt strings to hashes

## Dependencies

**Updated Dependencies**:

```
"@colony/colony-js-adapter-ethers": "1.7.0",
"@colony/colony-js-client": "1.7.3",
"@colony/colony-js-contract-loader-http": "1.6.2",
```

## Resolves

#39 and #40
