### PR TITLE
Add docker pull to initialization script

### DIFF
--- a/packages/colony-starter-react/scripts/initialize_project.sh
+++ b/packages/colony-starter-react/scripts/initialize_project.sh
@@ -18,6 +18,10 @@ git init
 log "Adding gitignore file..."
 echo "node_modules" >> .gitignore
 
+# Pull docker image
+log "Pulling docker image..."
+docker pull ethereum/solc:0.4.23
+
 # Add colonyNetwork submodule
 log "Adding colonyNetwork submodule..."
 git submodule add https://github.com/JoinColony/colonyNetwork src/lib/colonyNetwork


### PR DESCRIPTION
## Description

This pull request adds `docker pull ethereum/solc:0.4.23` to the initialization script.

## Scripts

**Updated Scripts**:

`initialize_project.sh`

```
# Pull docker image
log "Pulling docker image..."
docker pull ethereum/solc:0.4.23
```

## Resolves

```
Error: No such image: ethereum/solc:0.4.23
Error: Please pull 0.4.23 from docker before trying to compile with it
```