### PR TITLE
Convert domainId to number on createTask

### DIFF
--- a/packages/colony-starter-react/src/client/containers/Manage/Tasks/CreateTask.jsx
+++ b/packages/colony-starter-react/src/client/containers/Manage/Tasks/CreateTask.jsx
@@ -39,6 +39,9 @@ class CreateTaskContainer extends Component {
       case 'specification-title':
         task.specification[event.target.id.substring(14)] = event.target.value
         break
+      case 'domainId':
+        task.domainId[event.target.id] = Number(event.target.value)
+        break
       default:
         task[event.target.id] = event.target.value
         break


### PR DESCRIPTION
## Description

Convert `domainId` to number on `handleChange` within `CreatTask` container.

## Resolves

```
Validation failed for createTask: Parameter "domainId" expected a value of type "number"
```