### PR TITLE
Allow colonyNetwork version to be specified on deploy

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -2,17 +2,17 @@
 
 ### Prerequisites
 
-- Yarn 1.12.3
-- Docker
-- Node 10.12.0
+- Node `>=10.12.0`
+- Yarn `>=1.12.0`
+- Docker `>=18.09.0`
 
 _You may find it helpful to use Node Version Manager (`nvm`) to manage Node versions._
 
 _If you are a Linux user, check out the [Linux Setup](/.github/LINUX_SETUP.md) page to ensure Yarn and Docker are set up accordingly._
 
-### Install Dependencies
+### Install
 
-Install development dependencies:
+Install dependencies for all packages:
 
 ```
 yarn
@@ -44,7 +44,7 @@ yarn start-trufflepig
 
 ### Run Tests
 
-Open a new terminal window and run tests:
+Open a new terminal window and run the tests for all packages:
 
 ```
 yarn test
@@ -55,5 +55,13 @@ yarn test
 Open a new terminal window and test install a package:
 
 ```
-yarn colony-starter [colony-starter-package]
+yarn colony build [package-name]
+```
+
+### Publish Packages
+
+Update package versions and publish packages independently:
+
+```
+yarn lerna publish
 ```

--- a/README.md
+++ b/README.md
@@ -73,15 +73,15 @@ Check out some of the other starter packages by repeating steps 2 and 3 and subs
 
 [colony-starter](/packages/colony-starter)
 
-- A boilerplate to get started with [colonyJS](https://github.com/JoinColony/colonyJS).
+- A boilerplate using [colonyJS](https://github.com/JoinColony/colonyJS).
 
 [colony-starter-react](/packages/colony-starter-react)
 
-- A boilerplate to get started with [colonyJS](https://github.com/JoinColony/colonyJS) using React.
+- A boilerplate using [colonyJS](https://github.com/JoinColony/colonyJS) with React.
 
 [colony-starter-angular](/packages/colony-starter-angular)
 
-- A boilerplate to get started with [colonyJS](https://github.com/JoinColony/colonyJS) using Angular.
+- A boilerplate using [colonyJS](https://github.com/JoinColony/colonyJS) with Angular.
 
 ### Example Packages
 

--- a/docs/_Docs_Overview.md
+++ b/docs/_Docs_Overview.md
@@ -62,15 +62,15 @@ Check out some of the other starter packages by repeating steps 2 and 3 and subs
 
 [colony-starter](/starters-colony-starter)
 
-- This package is a boilerplate with no framework.
+- A boilerplate using [colonyJS](https://github.com/JoinColony/colonyJS).
 
 [colony-starter-react](/starters-colony-starter-react)
 
-- This package is a boilerplate using react.
+- A boilerplate using [colonyJS](https://github.com/JoinColony/colonyJS) with React.
 
 [colony-starter-angular](/starters-colony-starter-angular)
 
-- This package is a boilerplate using angular.
+- A boilerplate using [colonyJS](https://github.com/JoinColony/colonyJS) with Angular.
 
 ### Example Packages
 
@@ -78,11 +78,11 @@ We also have a couple example packages that you can unpack using the same `build
 
 [colony-example](/examples-colony-example)
 
-- This package is a built out version of the `colony-starter` package with more examples.
+- A built out version of the [colony-starter](/starters-colony-starter) package with more examples.
 
 [colony-example-react](/examples-colony-example-react)
 
-- This package is a built out version of the `colony-starter-react` package with more examples.
+- A built out version of the [colony-starter-react](/starters-colony-starter-react) package with more examples.
 
 ## Contribute
 

--- a/packages/colony-cli/README.md
+++ b/packages/colony-cli/README.md
@@ -44,6 +44,12 @@ Deploy the [colonyNetwork](https://github.com/JoinColony/colonyNetwork) smart co
 colony service deploy-contracts
 ```
 
+Deploy a specific version of the [colonyNetwork](https://github.com/JoinColony/colonyNetwork) smart contracts:
+
+```
+colony service deploy-contracts --specific develop
+```
+
 Serve truffle contract data with [TrufflePig](https://github.com/JoinColony/trufflepig):
 
 ```

--- a/packages/colony-cli/package.json
+++ b/packages/colony-cli/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0-beta.0",
   "description": "A command line tool for building with Colony",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "bin": {
     "colony": "src/index.js"
   },

--- a/packages/colony-cli/scripts/deploy_contracts.sh
+++ b/packages/colony-cli/scripts/deploy_contracts.sh
@@ -1,7 +1,44 @@
 #!/bin/bash
 
+# Paths
+ROOT_PATH=$(pwd)
+
+# Log
+log() {
+  CYAN='\033[0;36m'
+  NONE='\033[0m'
+  echo "${CYAN}$1${NONE}"
+}
+
 # Move to colonyNetwork directory
 cd lib/colonyNetwork
+
+# If version specified
+if [ $1 ]; then
+
+  # Set colonyNework version
+  log "Checking out colonyNetwork version..."
+  git -c advice.detachedHead=false checkout $1
+
+else
+
+  # Set colonyNework version
+  log "Checking out colonyNetwork version..."
+  git -c advice.detachedHead=false checkout temp/eth-denver
+
+fi
+
+# Install colonyNetwork dependencies
+log "Installing colonyNetwork dependencies..."
+yarn
+
+# Initialize colonyNetwork submodules
+log "Initializing colonyNetwork submodules..."
+git submodule update --init --recursive
+
+# Provision colonyNetwork submodules
+log "Provisioning colonyNetwork submodules..."
+yarn run provision:token:contracts
 
 # Compile and deploy colonyNetwork contracts
 ./node_modules/.bin/truffle migrate --compile-all --reset

--- a/packages/colony-cli/scripts/postinstall.sh
+++ b/packages/colony-cli/scripts/postinstall.sh
@@ -23,7 +23,7 @@ cd lib/colonyNetwork
 
 # Set colonyNework version
 log "Checking out colonyNetwork version..."
-git -c advice.detachedHead=false checkout 9bba127b0286708d4f8919526a943b0e916cfd7c
+git -c advice.detachedHead=false checkout temp/eth-denver
 
 # Install colonyNetwork dependencies
 log "Installing colonyNetwork dependencies..."

--- a/packages/colony-cli/src/actions/service.js
+++ b/packages/colony-cli/src/actions/service.js
@@ -36,8 +36,15 @@ const service = async (commander, serviceName) => {
     console.log(`  Deploying the colonyNetwork smart contracts...`);
     console.log();
 
-    // Start trufflepig
-    cp.execSync('sh scripts/deploy_contracts.sh', { stdio: [0, 1, 2] });
+    // Deploy contracts
+    if (commander.specific) {
+      cp.execSync(
+        `sh scripts/deploy_contracts.sh ${commander.specific}`,
+        { stdio: [0, 1, 2] },
+      );
+    } else {
+      cp.execSync(`sh scripts/deploy_contracts.sh`, { stdio: [0, 1, 2] });
+    }
 
   } else if (serviceName === 'seed-network') {
 
@@ -46,7 +53,7 @@ const service = async (commander, serviceName) => {
     console.log(`  Adding global skills to the Meta Colony...`);
     console.log();
 
-    // Start trufflepig
+    // Seed network
     cp.execSync('node scripts/seed_network.js', { stdio: [0, 1, 2] });
 
   } else if (serviceName === 'start-trufflepig') {

--- a/packages/colony-example-react/README.md
+++ b/packages/colony-example-react/README.md
@@ -103,3 +103,11 @@ Open a new terminal window and run the example tests:
 ```
 yarn test
 ```
+
+## Contract Versions
+
+If you do not want to use the default version of the [colonyNetwork](https://github.com/JoinColony/colonyNetwork) smart contracts defined by the [colony-cli](/packages/colony-cli) package, you can update the `"deploy-contracts"` scripts property in your `package.json` file to use a specific version. This can be a branch name, a commit hash, or a version tag.
+
+```
+"deploy-contracts": "colony service deploy-contracts --specific develop",
+```

--- a/packages/colony-example-react/package.json
+++ b/packages/colony-example-react/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0-beta.0",
   "description": "A simple example project built with Colony",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=10.12.0"
   },

--- a/packages/colony-example/README.md
+++ b/packages/colony-example/README.md
@@ -87,3 +87,11 @@ Open a new terminal window and run the example tests:
 ```
 yarn test
 ```
+
+## Contract Versions
+
+If you do not want to use the default version of the [colonyNetwork](https://github.com/JoinColony/colonyNetwork) smart contracts defined by the [colony-cli](/packages/colony-cli) package, you can update the `"deploy-contracts"` scripts property in your `package.json` file to use a specific version. This can be a branch name, a commit hash, or a version tag.
+
+```
+"deploy-contracts": "colony service deploy-contracts --specific develop",
+```

--- a/packages/colony-example/package.json
+++ b/packages/colony-example/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0-beta.0",
   "description": "A simple example project built with Colony",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=10.12.0"
   },

--- a/packages/colony-starter-angular/README.md
+++ b/packages/colony-starter-angular/README.md
@@ -101,3 +101,11 @@ Open a new terminal window and run the tests:
 ```
 yarn test
 ```
+
+## Contract Versions
+
+If you do not want to use the default version of the [colonyNetwork](https://github.com/JoinColony/colonyNetwork) smart contracts defined by the [colony-cli](/packages/colony-cli) package, you can update the `"deploy-contracts"` scripts property in your `package.json` file to use a specific version. This can be a branch name, a commit hash, or a version tag.
+
+```
+"deploy-contracts": "colony service deploy-contracts --specific develop",
+```

--- a/packages/colony-starter-angular/package.json
+++ b/packages/colony-starter-angular/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0-beta.2",
   "description": "A simple starter project for building with Colony",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=10.12.0"
   },

--- a/packages/colony-starter-react/README.md
+++ b/packages/colony-starter-react/README.md
@@ -101,3 +101,11 @@ Open a new terminal window and run the example tests:
 ```
 yarn test
 ```
+
+## Contract Versions
+
+If you do not want to use the default version of the [colonyNetwork](https://github.com/JoinColony/colonyNetwork) smart contracts defined by the [colony-cli](/packages/colony-cli) package, you can update the `"deploy-contracts"` scripts property in your `package.json` file to use a specific version. This can be a branch name, a commit hash, or a version tag.
+
+```
+"deploy-contracts": "colony service deploy-contracts --specific develop",
+```

--- a/packages/colony-starter-react/package.json
+++ b/packages/colony-starter-react/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0-beta.7",
   "description": "A simple starter project for building with Colony",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=10.12.0"
   },

--- a/packages/colony-starter/README.md
+++ b/packages/colony-starter/README.md
@@ -87,3 +87,11 @@ Open a new terminal window and run the example tests:
 ```
 yarn test
 ```
+
+## Contract Versions
+
+If you do not want to use the default version of the [colonyNetwork](https://github.com/JoinColony/colonyNetwork) smart contracts defined by the [colony-cli](/packages/colony-cli) package, you can update the `"deploy-contracts"` scripts property in your `package.json` file to use a specific version. This can be a branch name, a commit hash, or a version tag.
+
+```
+"deploy-contracts": "colony service deploy-contracts --specific develop",
+```

--- a/packages/colony-starter/package.json
+++ b/packages/colony-starter/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0-beta.6",
   "description": "A simple starter project for building with Colony",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=10.12.0"
   },


### PR DESCRIPTION
## Description

This pull request gives developers the option of using the `--specific` flag with the `deploy-contracts` service command, which will configure the colonyNetwork submodule to that version before deploying the contracts to the local test network.

## Other Changes

- [X] Readd public access config
- [X] Update development documentation
- [X] Update colonyNetwork version to `temp/eth-denver`
- [X] Add instructions for upgrading colonyNetwork versions

## Related Issues

Closes #67