### PR TITLE
Fix CI check in colony-cli postinstall script

### DIFF
--- a/packages/colony-cli/scripts/postinstall.sh
+++ b/packages/colony-cli/scripts/postinstall.sh
@@ -10,7 +10,7 @@ if [ ! -d "lib/colonyNetwork" ]; then
   mkdir lib && cd lib
 
   # Check CI variable
-  if [ -z $CI ]; then
+  if [ $CI ]; then
 
     # Clone colonyNetwork repository using ssh
     git clone ssh://git@github.com/JoinColony/colonyNetwork.git

--- a/packages/colony-cli/src/services/deploy_contracts.sh
+++ b/packages/colony-cli/src/services/deploy_contracts.sh
@@ -7,6 +7,10 @@ log() {
   echo "${CYAN}$1${NONE}"
 }
 
+# Check ssh connection
+log "Checking ssh connection..."
+ssh -T git@github.com
+
 # Check for specified version
 if [ $1 ]; then
 


### PR DESCRIPTION
## Description

This pull request fixes the check for the CI boolean in the `postinstall.sh` script of `colony-cli`.

## Other Changes

This pull request also checks if ssh is connected in the `deploy-contracts` script. This is a temporary solution until JoinColony/colonyToken#15 has been merged.

## Related Issues

Closes #92