### PR TITLE
fix broken links in colonystarter pages

### DIFF
--- a/docs/_CLI_ColonyCLI.md
+++ b/docs/_CLI_ColonyCLI.md
@@ -14,7 +14,7 @@ The `colony-cli` package is a command line tool for building [colonyStarter](htt
 
 _You may find it helpful to use Node Version Manager (`nvm`) to manage Node versions._
 
-_If you are using Linux, check out [Linux Setup](/docs-linux-setup/) to ensure Yarn and Docker are set up accordingly._
+_If you are using Linux, check out [Linux Setup](/colonystarter/docs-linux-setup/) to ensure Yarn and Docker are set up accordingly._
 
 ## Install
 

--- a/docs/_Docs_Overview.md
+++ b/docs/_Docs_Overview.md
@@ -16,11 +16,11 @@ _Get a head start on your next project!_ Colony Starter (formerly known as "Hack
 
 _You may find it helpful to use Node Version Manager (`nvm`) to manage Node versions._
 
-_If you are using Linux, check out [Linux Setup](/docs-linux-setup) to ensure Yarn and Docker are set up accordingly._
+_If you are using Linux, check out [Linux Setup](/colonystarter/docs-linux-setup) to ensure Yarn and Docker are set up accordingly._
 
 ### Step 1
 
-Globally install the [colony-cli](/cli-colony-cli) package.
+Globally install the [colony-cli](/colonystarter/cli-colony-cli) package.
 
 ```
 yarn global add @colony/colony-cli
@@ -28,7 +28,7 @@ yarn global add @colony/colony-cli
 
 ### Step 2
 
-Move to your working directory and unpack the [colony-starter](/starters-colony-starter) package:
+Move to your working directory and unpack the [colony-starter](/colonystarter/starters-colony-starter) package:
 
 ```
 colony build colony-starter
@@ -36,7 +36,7 @@ colony build colony-starter
 
 ### Step 3
 
-Move to your new project directory and check out [colony-starter](/starters-colony-starter) for further instructions:
+Move to your new project directory and check out [colony-starter](/colonystarter/starters-colony-starter) for further instructions:
 
 ```
 cd colony-starter
@@ -44,7 +44,7 @@ cd colony-starter
 
 ### Using NPX
 
-Alternatively, you can use [npx](https://www.npmjs.com/package/npx) and unpack the [colony-starter](/packages/colony-starter) package without installing the [colony-cli](/packages/colony-cli) package.
+Alternatively, you can use [npx](https://www.npmjs.com/package/npx) and unpack the [colony-starter](/colonystarter/colony-starter) package without installing the [colony-cli](/colonystarter/colony-cli) package.
 
 ```
 npx -p @colony/colony-cli colony build colony-starter
@@ -60,19 +60,19 @@ The `colony-cli` package is a command line tool for building [colonyStarter](htt
 
 Check out some of the other starter packages by repeating steps 2 and 3 and substituting `colony-starter` with the package of your choice. If you have ideas for new packages or improvements, feel free to open an issue or pull request.
 
-[colony-starter](/starters-colony-starter)
+[colony-starter](/colonystarter/starters-colony-starter)
 
 - A boilerplate using [colonyJS](https://github.com/JoinColony/colonyJS).
 
-[colony-starter-react](/starters-colony-starter-react)
+[colony-starter-react](/colonystarter/starters-colony-starter-react)
 
 - A boilerplate using [colonyJS](https://github.com/JoinColony/colonyJS) with React.
 
-[colony-starter-angular](/starters-colony-starter-angular)
+[colony-starter-angular](/colonystarter/starters-colony-starter-angular)
 
 - A boilerplate using [colonyJS](https://github.com/JoinColony/colonyJS) with Angular.
 
-[colony-starter-contract](/packages/colony-starter-contract)
+[colony-starter-contract](/colonystarter/colony-starter-contract)
 
 - A boilerplate to start building extension contracts alongside [colonyNetwork](https://github.com/JoinColony/colonyNetwork).
 
@@ -80,17 +80,17 @@ Check out some of the other starter packages by repeating steps 2 and 3 and subs
 
 We also have a couple example packages that you can unpack using the same `build` command. If you are uncertain how to do something, it might be helpful to use one of these packages as a reference.
 
-[colony-example](/examples-colony-example)
+[colony-example](/colonystarter/examples-colony-example)
 
-- A built out version of the [colony-starter](/starters-colony-starter) package with more examples.
+- A built out version of the [colony-starter](/colonystarter/starters-colony-starter) package with more examples.
 
-[colony-example-react](/examples-colony-example-react)
+[colony-example-react](/colonystarter/examples-colony-example-react)
 
-- A built out version of the [colony-starter-react](/starters-colony-starter-react) package with more examples.
+- A built out version of the [colony-starter-react](/colonystarter/starters-colony-starter-react) package with more examples.
 
-[colony-example-angular](/examples-colony-example-angular)
+[colony-example-angular](/colonystarter/examples-colony-example-angular)
 
-- A built out version of the [colony-starter-angular](/starters-colony-starter-angular) package with more examples.
+- A built out version of the [colony-starter-angular](/colonystarter/starters-colony-starter-angular) package with more examples.
 
 ## Contribute
 

--- a/docs/_Examples_ColonyExample.md
+++ b/docs/_Examples_ColonyExample.md
@@ -6,7 +6,7 @@ order: 1
 
 _An example project using [colonyJS](https://github.com/JoinColony/colonyJS)!_
 
-This is a built out version of the [colony-starter](/starters-colony-starter) package with more examples.
+This is a built out version of the [colony-starter](/colonystarter/starters-colony-starter) package with more examples.
 
 ## Prerequisites
 
@@ -16,11 +16,11 @@ This is a built out version of the [colony-starter](/starters-colony-starter) pa
 
 _You may find it helpful to use Node Version Manager (`nvm`) to manage Node versions._
 
-_If you are using Linux, check out [Linux Setup](/docs-linux-setup/) to ensure Yarn and Docker are set up accordingly._
+_If you are using Linux, check out [Linux Setup](/colonystarter/docs-linux-setup/) to ensure Yarn and Docker are set up accordingly._
 
 ## Installation
 
-Globally install the [colony-cli](/cli-colony-cli) package.
+Globally install the [colony-cli](/colonystarter/cli-colony-cli) package.
 
 ```
 yarn global add @colony/colony-cli

--- a/docs/_Examples_ColonyExampleAngular.md
+++ b/docs/_Examples_ColonyExampleAngular.md
@@ -6,7 +6,7 @@ order: 3
 
 _An example project using [colonyJS](https://github.com/JoinColony/colonyJS) with Angular!_
 
-This is a built out version of the [colony-starter-angular](/starters-colony-starter-angular) package with more examples.
+This is a built out version of the [colony-starter-angular](/colonystarter/starters-colony-starter-angular) package with more examples.
 
 ## Prerequisites
 
@@ -16,11 +16,11 @@ This is a built out version of the [colony-starter-angular](/starters-colony-sta
 
 _You may find it helpful to use Node Version Manager (`nvm`) to manage Node versions._
 
-_If you are using Linux, check out [Linux Setup](/docs-linux-setup/) to ensure Yarn and Docker are set up accordingly._
+_If you are using Linux, check out [Linux Setup](/colonystarter/docs-linux-setup/) to ensure Yarn and Docker are set up accordingly._
 
 ## Installation
 
-Globally install the [colony-cli](/cli-colony-cli) package.
+Globally install the [colony-cli](/colonystarter/cli-colony-cli) package.
 
 ```
 yarn global add @colony/colony-cli

--- a/docs/_Examples_ColonyExampleReact.md
+++ b/docs/_Examples_ColonyExampleReact.md
@@ -6,7 +6,7 @@ order: 2
 
 _An example project using [colonyJS](https://github.com/JoinColony/colonyJS) with React!_
 
-This is a built out version of the [colony-starter-react](/starters-colony-starter-react) package with more examples.
+This is a built out version of the [colony-starter-react](/colonystarter/starters-colony-starter-react) package with more examples.
 
 ## Prerequisites
 
@@ -16,11 +16,11 @@ This is a built out version of the [colony-starter-react](/starters-colony-start
 
 _You may find it helpful to use Node Version Manager (`nvm`) to manage Node versions._
 
-_If you are using Linux, check out [Linux Setup](/docs-linux-setup/) to ensure Yarn and Docker are set up accordingly._
+_If you are using Linux, check out [Linux Setup](/colonystarter/docs-linux-setup/) to ensure Yarn and Docker are set up accordingly._
 
 ## Installation
 
-Globally install the [colony-cli](/cli-colony-cli) package.
+Globally install the [colony-cli](/colonystarter/cli-colony-cli) package.
 
 ```
 yarn global add @colony/colony-cli

--- a/docs/_Starters_ColonyStarter.md
+++ b/docs/_Starters_ColonyStarter.md
@@ -14,11 +14,11 @@ _A boilerplate to get started with [colonyJS](https://github.com/JoinColony/colo
 
 _You may find it helpful to use Node Version Manager (`nvm`) to manage Node versions._
 
-_If you are using Linux, check out [Linux Setup](/docs-linux-setup/) to ensure Yarn and Docker are set up accordingly._
+_If you are using Linux, check out [Linux Setup](/colonystarter/docs-linux-setup/) to ensure Yarn and Docker are set up accordingly._
 
 ## Installation
 
-Globally install the [colony-cli](/cli-colony-cli) package.
+Globally install the [colony-cli](/colonystarter/cli-colony-cli) package.
 
 ```
 yarn global add @colony/colony-cli

--- a/docs/_Starters_ColonyStarterAngular.md
+++ b/docs/_Starters_ColonyStarterAngular.md
@@ -14,11 +14,11 @@ _A boilerplate to get started with [colonyJS](https://github.com/JoinColony/colo
 
 _You may find it helpful to use Node Version Manager (`nvm`) to manage Node versions._
 
-_If you are using Linux, check out [Linux Setup](/docs-linux-setup/) to ensure Yarn and Docker are set up accordingly._
+_If you are using Linux, check out [Linux Setup](/colonystarter/docs-linux-setup/) to ensure Yarn and Docker are set up accordingly._
 
 ## Installation
 
-Globally install the [colony-cli](/cli-colony-cli) package.
+Globally install the [colony-cli](/colonystarter/cli-colony-cli) package.
 
 ```
 yarn global add @colony/colony-cli

--- a/docs/_Starters_ColonyStarterContract.md
+++ b/docs/_Starters_ColonyStarterContract.md
@@ -14,11 +14,11 @@ _A boilerplate to start building extension contracts alongside [colonyNetwork](h
 
 _You may find it helpful to use Node Version Manager (`nvm`) to manage Node versions._
 
-_If you are using Linux, check out [Linux Setup](/docs-linux-setup/) to ensure Yarn and Docker are set up accordingly._
+_If you are using Linux, check out [Linux Setup](/colonystarter/docs-linux-setup/) to ensure Yarn and Docker are set up accordingly._
 
 ## Installation
 
-Globally install the [colony-cli](/cli-colony-cli) package.
+Globally install the [colony-cli](/colonystarter/cli-colony-cli) package.
 
 ```
 yarn global add @colony/colony-cli
@@ -30,7 +30,7 @@ Install the `colony-starter-contract` package.
 colony build colony-starter-contract
 ```
 
-Alternatively, you can use [npx](https://www.npmjs.com/package/npx) and kickstart the `colony-starter-contract` package in one line without having to globally add the [colony-cli](/cli-colony-cli) package:
+Alternatively, you can use [npx](https://www.npmjs.com/package/npx) and kickstart the `colony-starter-contract` package in one line without having to globally add the [colony-cli](/colonystarter/cli-colony-cli) package:
 
 ```
 npx -p @colony/colony-cli colony build colony-starter-contract
@@ -80,7 +80,7 @@ yarn truffle [develop/compile/migrate/test]
 
 ## Contract Versions
 
-If you do not want to use the default version of the [colonyNetwork](https://github.com/JoinColony/colonyNetwork) smart contracts defined by the [colony-cli](/packages/colony-cli) package, you can update the `"deploy-contracts"` scripts property in your `package.json` file to use a specific version. This can be a branch name, a commit hash, or a version tag.
+If you do not want to use the default version of the [colonyNetwork](https://github.com/JoinColony/colonyNetwork) smart contracts defined by the [colony-cli](/colonystarter/colony-cli) package, you can update the `"deploy-contracts"` scripts property in your `package.json` file to use a specific version. This can be a branch name, a commit hash, or a version tag.
 
 ```
 "deploy-contracts": "colony service deploy-contracts --specific develop",

--- a/docs/_Starters_ColonyStarterReact.md
+++ b/docs/_Starters_ColonyStarterReact.md
@@ -14,11 +14,11 @@ _A boilerplate to get started with [colonyJS](https://github.com/JoinColony/colo
 
 _You may find it helpful to use Node Version Manager (`nvm`) to manage Node versions._
 
-_If you are using Linux, check out [Linux Setup](/docs-linux-setup/) to ensure Yarn and Docker are set up accordingly._
+_If you are using Linux, check out [Linux Setup](/colonystarter/docs-linux-setup/) to ensure Yarn and Docker are set up accordingly._
 
 ## Installation
 
-Globally install the [colony-cli](/cli-colony-cli) package.
+Globally install the [colony-cli](/colonystarter/cli-colony-cli) package.
 
 ```
 yarn global add @colony/colony-cli
@@ -30,7 +30,7 @@ Install the `colony-starter-react` package.
 colony build colony-starter-react
 ```
 
-Alternatively, you can use [npx](https://www.npmjs.com/package/npx) and kickstart the `colony-starter-react` package in one line without having to globally add the [colony-cli](/cli-colony-cli) package:
+Alternatively, you can use [npx](https://www.npmjs.com/package/npx) and kickstart the `colony-starter-react` package in one line without having to globally add the [colony-cli](/colonystarter/cli-colony-cli) package:
 
 ```
 npx -p @colony/colony-starter colony build colony-starter-react

--- a/yarn.lock
+++ b/yarn.lock
@@ -1110,6 +1110,22 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
+"@colony/colony-cli@1.0.0-beta.4":
+  version "1.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@colony/colony-cli/-/colony-cli-1.0.0-beta.4.tgz#001bc5444cfa5cdb24874fdce43a71859587955c"
+  integrity sha512-VgSzMOsBpisH161eShpdxkvZV9tWg0/jhv7y1kfsaPisY0zM4eoeowBumgJEZleFdG86aA5YKkIUvQ/fWul07Q==
+  dependencies:
+    "@colony/colony-js-client" "^1.11.2"
+    "@colony/purser-software" "^1.2.4"
+    chalk "^2.4.1"
+    commander "^2.17.1"
+    cross-spawn "^6.0.5"
+    fs-extra "^7.0.0"
+    json "^9.0.6"
+    tar-pack "^3.4.1"
+    tmp "^0.0.33"
+    trufflepig "^1.1.1"
+
 "@colony/colony-js-adapter-ethers@^1.10.0":
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/@colony/colony-js-adapter-ethers/-/colony-js-adapter-ethers-1.10.0.tgz#4a6525476ef872a0c544d91bf30b7d4244cb8c9a"


### PR DESCRIPTION
## Description

While running through some of the examples I noticed that a lot of links are broken, cuz none of them are prepended with `/colonystarter/` -- so they 404. 

This fixes everything in colonyStarter I think, but keep your eyes out for more if you're ever poking around in the docs, folks! 