### PR TITLE
Add domainId when removing admin in colony-example-react

### DIFF
--- a/packages/colony-example-react/src/actions/adminActions.jsx
+++ b/packages/colony-example-react/src/actions/adminActions.jsx
@@ -96,6 +96,7 @@ export const removeAdmin = (colonyClient, userAddress) => ({
     // Remove admin
     const tx = await colonyClient.setAdministrationRole.send({
       address: userAddress,
+      domainId: 1,
       setTo: false,
     })
 


### PR DESCRIPTION
## Description

`removeAdmin` action had a validation error because of missing `domainId` param”