### PR TITLE
Fix colony-setup script in colony-example-angular

### DIFF
--- a/docs/_Examples_ColonyExample.md
+++ b/docs/_Examples_ColonyExample.md
@@ -38,9 +38,7 @@ Alternatively, you can use [npx](https://www.npmjs.com/package/npx) and kickstar
 npx -p @colony/colony-cli colony build colony-example
 ```
 
-## Run Examples
-
-### Start Network
+## Start Network
 
 Open a new terminal window and start [Ganache](https://github.com/trufflesuite/ganache-cli):
 
@@ -48,7 +46,7 @@ Open a new terminal window and start [Ganache](https://github.com/trufflesuite/g
 yarn start-ganache
 ```
 
-### Deploy Contracts
+## Deploy Contracts
 
 Open a new terminal window and deploy the [colonyNetwork](https://github.com/JoinColony/colonyNetwork) contracts:
 
@@ -56,7 +54,7 @@ Open a new terminal window and deploy the [colonyNetwork](https://github.com/Joi
 yarn deploy-contracts
 ```
 
-### Start TrufflePig
+## Start TrufflePig
 
 Once the contracts have been deployed, start [TrufflePig](https://github.com/JoinColony/trufflepig):
 
@@ -64,7 +62,7 @@ Once the contracts have been deployed, start [TrufflePig](https://github.com/Joi
 yarn start-trufflepig
 ```
 
-### Run Script
+## Run Script
 
 Open a new terminal window and run the example script:
 
@@ -72,7 +70,7 @@ Open a new terminal window and run the example script:
 yarn start
 ```
 
-### Run Tests
+## Run Tests
 
 Open a new terminal window and run the example tests:
 

--- a/docs/_Examples_ColonyExampleAngular.md
+++ b/docs/_Examples_ColonyExampleAngular.md
@@ -38,9 +38,7 @@ Alternatively, you can use [npx](https://www.npmjs.com/package/npx) and kickstar
 npx -p @colony/colony-starter colony build colony-example-angular
 ```
 
-## Run Examples
-
-### Start Network
+## Start Network
 
 Open a new terminal window and start [Ganache](https://github.com/trufflesuite/ganache-cli):
 
@@ -48,7 +46,7 @@ Open a new terminal window and start [Ganache](https://github.com/trufflesuite/g
 yarn start-ganache
 ```
 
-### Deploy Contracts
+## Deploy Contracts
 
 Open a new terminal window and deploy the [colonyNetwork](https://github.com/JoinColony/colonyNetwork) contracts:
 
@@ -56,7 +54,7 @@ Open a new terminal window and deploy the [colonyNetwork](https://github.com/Joi
 yarn deploy-contracts
 ```
 
-### Start TrufflePig
+## Start TrufflePig
 
 Once the contracts have been deployed, start [TrufflePig](https://github.com/JoinColony/trufflepig):
 
@@ -64,7 +62,7 @@ Once the contracts have been deployed, start [TrufflePig](https://github.com/Joi
 yarn start-trufflepig
 ```
 
-### Seed Network
+## Seed Network
 
 Open a new terminal window and run the seed network script:
 
@@ -72,7 +70,7 @@ Open a new terminal window and run the seed network script:
 yarn seed-network
 ```
 
-### Start Server
+## Start Server
 
 Once the network has been seeded, start the development server:
 
@@ -80,13 +78,13 @@ Once the network has been seeded, start the development server:
 yarn start
 ```
 
-### Open Browser
+## Open Browser
 
 Open your browser and check out the example angular app:
 
 [localhost:4200](http://localhost:4200)
 
-### Run Tests
+## Run Tests
 
 Open a new terminal window and run the example tests:
 

--- a/docs/_Examples_ColonyExampleAngular.md
+++ b/docs/_Examples_ColonyExampleAngular.md
@@ -72,17 +72,9 @@ Open a new terminal window and run the seed network script:
 yarn seed-network
 ```
 
-### Colony Setup
-
-Once the network has been seeded, run the colony setup script:
-
-```
-yarn colony-setup
-```
-
 ### Start Server
 
-Once your colony has been set up, start the development server:
+Once the network has been seeded, start the development server:
 
 ```
 yarn start
@@ -90,7 +82,7 @@ yarn start
 
 ### Open Browser
 
-Open your browser and check out the example angular app::
+Open your browser and check out the example angular app:
 
 [localhost:4200](http://localhost:4200)
 

--- a/docs/_Examples_ColonyExampleReact.md
+++ b/docs/_Examples_ColonyExampleReact.md
@@ -38,9 +38,7 @@ Alternatively, you can use [npx](https://www.npmjs.com/package/npx) and kickstar
 npx -p @colony/colony-starter colony build colony-example-react
 ```
 
-## Run Examples
-
-### Start Network
+## Start Network
 
 Open a new terminal window and start [Ganache](https://github.com/trufflesuite/ganache-cli):
 
@@ -48,7 +46,7 @@ Open a new terminal window and start [Ganache](https://github.com/trufflesuite/g
 yarn start-ganache
 ```
 
-### Deploy Contracts
+## Deploy Contracts
 
 Open a new terminal window and deploy the [colonyNetwork](https://github.com/JoinColony/colonyNetwork) contracts:
 
@@ -56,7 +54,7 @@ Open a new terminal window and deploy the [colonyNetwork](https://github.com/Joi
 yarn deploy-contracts
 ```
 
-### Start TrufflePig
+## Start TrufflePig
 
 Once the contracts have been deployed, start [TrufflePig](https://github.com/JoinColony/trufflepig):
 
@@ -64,7 +62,7 @@ Once the contracts have been deployed, start [TrufflePig](https://github.com/Joi
 yarn start-trufflepig
 ```
 
-### Seed Network
+## Seed Network
 
 Open a new terminal window and run the seed network script:
 
@@ -72,7 +70,7 @@ Open a new terminal window and run the seed network script:
 yarn seed-network
 ```
 
-### Start Server
+## Start Server
 
 Once the network has been seeded, start the development server:
 
@@ -80,13 +78,13 @@ Once the network has been seeded, start the development server:
 yarn start
 ```
 
-### Open Browser
+## Open Browser
 
 Open your browser and check out the example react app:
 
 [localhost:8080](http://localhost:8080)
 
-### Run Tests
+## Run Tests
 
 Open a new terminal window and run the example tests:
 

--- a/docs/_Examples_ColonyExampleReact.md
+++ b/docs/_Examples_ColonyExampleReact.md
@@ -72,17 +72,9 @@ Open a new terminal window and run the seed network script:
 yarn seed-network
 ```
 
-### Colony Setup
-
-Once the network has been seeded, run the colony setup script:
-
-```
-yarn colony-setup
-```
-
 ### Start Server
 
-Once your colony has been set up, start the development server:
+Once the network has been seeded, start the development server:
 
 ```
 yarn start
@@ -90,7 +82,7 @@ yarn start
 
 ### Open Browser
 
-Open your browser and check out the example react app::
+Open your browser and check out the example react app:
 
 [localhost:8080](http://localhost:8080)
 

--- a/docs/_Starters_ColonyStarter.md
+++ b/docs/_Starters_ColonyStarter.md
@@ -36,9 +36,7 @@ Alternatively, you can use [npx](https://www.npmjs.com/package/npx) and kickstar
 npx -p @colony/colony-starter colony build colony-starter
 ```
 
-## Run Examples
-
-### Start Network
+## Start Network
 
 Open a new terminal window and start [Ganache](https://github.com/trufflesuite/ganache-cli):
 
@@ -46,7 +44,7 @@ Open a new terminal window and start [Ganache](https://github.com/trufflesuite/g
 yarn start-ganache
 ```
 
-### Deploy Contracts
+## Deploy Contracts
 
 Open a new terminal window and deploy the [colonyNetwork](https://github.com/JoinColony/colonyNetwork) contracts:
 
@@ -54,7 +52,7 @@ Open a new terminal window and deploy the [colonyNetwork](https://github.com/Joi
 yarn deploy-contracts
 ```
 
-### Start TrufflePig
+## Start TrufflePig
 
 Once the contracts have been deployed, start [TrufflePig](https://github.com/JoinColony/trufflepig):
 
@@ -62,7 +60,7 @@ Once the contracts have been deployed, start [TrufflePig](https://github.com/Joi
 yarn start-trufflepig
 ```
 
-### Run Script
+## Run Script
 
 Open a new terminal window and run the example script:
 
@@ -70,7 +68,7 @@ Open a new terminal window and run the example script:
 yarn start
 ```
 
-### Run Tests
+## Run Tests
 
 Open a new terminal window and run the example tests:
 

--- a/docs/_Starters_ColonyStarterAngular.md
+++ b/docs/_Starters_ColonyStarterAngular.md
@@ -80,7 +80,7 @@ yarn colony-setup
 
 ### Start Server
 
-Once your colony has been set up, start the development server:
+Once your test colony has been set up, start the development server:
 
 ```
 yarn start
@@ -88,7 +88,7 @@ yarn start
 
 ### Open Browser
 
-Open your browser and check out the example angular app::
+Open your browser and check out the example angular app:
 
 [localhost:8080](http://localhost:8080)
 

--- a/docs/_Starters_ColonyStarterAngular.md
+++ b/docs/_Starters_ColonyStarterAngular.md
@@ -36,9 +36,7 @@ Alternatively, you can use [npx](https://www.npmjs.com/package/npx) and kickstar
 npx -p @colony/colony-cli colony build colony-starter-angular
 ```
 
-## Run Examples
-
-### Start Network
+## Start Network
 
 Open a new terminal window and start [Ganache](https://github.com/trufflesuite/ganache-cli):
 
@@ -46,7 +44,7 @@ Open a new terminal window and start [Ganache](https://github.com/trufflesuite/g
 yarn start-ganache
 ```
 
-### Deploy Contracts
+## Deploy Contracts
 
 Open a new terminal window and deploy the [colonyNetwork](https://github.com/JoinColony/colonyNetwork) contracts:
 
@@ -54,7 +52,7 @@ Open a new terminal window and deploy the [colonyNetwork](https://github.com/Joi
 yarn deploy-contracts
 ```
 
-### Start TrufflePig
+## Start TrufflePig
 
 Once the contracts have been deployed, start [TrufflePig](https://github.com/JoinColony/trufflepig):
 
@@ -62,7 +60,7 @@ Once the contracts have been deployed, start [TrufflePig](https://github.com/Joi
 yarn start-trufflepig
 ```
 
-### Seed Network
+## Seed Network
 
 Open a new terminal window and run the seed network script:
 
@@ -70,7 +68,7 @@ Open a new terminal window and run the seed network script:
 yarn seed-network
 ```
 
-### Colony Setup
+## Colony Setup
 
 Once the network has been seeded, run the colony setup script:
 
@@ -78,7 +76,7 @@ Once the network has been seeded, run the colony setup script:
 yarn colony-setup
 ```
 
-### Start Server
+## Start Server
 
 Once your test colony has been set up, start the development server:
 
@@ -86,13 +84,13 @@ Once your test colony has been set up, start the development server:
 yarn start
 ```
 
-### Open Browser
+## Open Browser
 
 Open your browser and check out the example angular app:
 
 [localhost:8080](http://localhost:8080)
 
-### Run Tests
+## Run Tests
 
 Open a new terminal window and run the example tests:
 

--- a/docs/_Starters_ColonyStarterContract.md
+++ b/docs/_Starters_ColonyStarterContract.md
@@ -36,9 +36,7 @@ Alternatively, you can use [npx](https://www.npmjs.com/package/npx) and kickstar
 npx -p @colony/colony-cli colony build colony-starter-contract
 ```
 
-## Development
-
-### Start Ganache
+## Start Ganache
 
 Open a new terminal window and start [Ganache](https://github.com/trufflesuite/ganache-cli):
 
@@ -46,7 +44,7 @@ Open a new terminal window and start [Ganache](https://github.com/trufflesuite/g
 yarn start-ganache
 ```
 
-### Deploy Contracts
+## Deploy Contracts
 
 Open a new terminal window and deploy the [colonyNetwork](https://github.com/JoinColony/colonyNetwork) contracts:
 
@@ -54,7 +52,7 @@ Open a new terminal window and deploy the [colonyNetwork](https://github.com/Joi
 yarn deploy-contracts
 ```
 
-### Start TrufflePig
+## Start TrufflePig
 
 Once the contracts have been deployed, start [TrufflePig](https://github.com/JoinColony/trufflepig):
 
@@ -62,7 +60,7 @@ Once the contracts have been deployed, start [TrufflePig](https://github.com/Joi
 yarn start-trufflepig
 ```
 
-### Colony Setup
+## Colony Setup
 
 Open a new terminal window and create a test colony:
 
@@ -70,7 +68,7 @@ Open a new terminal window and create a test colony:
 yarn colony-setup
 ```
 
-### Truffle Commands
+## Truffle Commands
 
 Run `truffle` commands using [colony-cli](https://github.com/JoinColony/colonyStarter/tree/master/packages/colony-cli):
 

--- a/docs/_Starters_ColonyStarterContract.md
+++ b/docs/_Starters_ColonyStarterContract.md
@@ -83,5 +83,5 @@ yarn truffle [develop/compile/migrate/test]
 If you do not want to use the default version of the [colonyNetwork](https://github.com/JoinColony/colonyNetwork) smart contracts defined by the [colony-cli](/colonystarter/colony-cli) package, you can update the `"deploy-contracts"` scripts property in your `package.json` file to use a specific version. This can be a branch name, a commit hash, or a version tag.
 
 ```
-"deploy-contracts": "colony service deploy-contracts --specific develop",
+"deploy-contracts": "colony service deploy-contracts --specific goerli-rc.1",
 ```

--- a/docs/_Starters_ColonyStarterReact.md
+++ b/docs/_Starters_ColonyStarterReact.md
@@ -36,9 +36,7 @@ Alternatively, you can use [npx](https://www.npmjs.com/package/npx) and kickstar
 npx -p @colony/colony-starter colony build colony-starter-react
 ```
 
-## Run Examples
-
-### Start Network
+## Start Network
 
 Open a new terminal window and start [Ganache](https://github.com/trufflesuite/ganache-cli):
 
@@ -46,7 +44,7 @@ Open a new terminal window and start [Ganache](https://github.com/trufflesuite/g
 yarn start-ganache
 ```
 
-### Deploy Contracts
+## Deploy Contracts
 
 Open a new terminal window and deploy the [colonyNetwork](https://github.com/JoinColony/colonyNetwork) contracts:
 
@@ -54,7 +52,7 @@ Open a new terminal window and deploy the [colonyNetwork](https://github.com/Joi
 yarn deploy-contracts
 ```
 
-### Start TrufflePig
+## Start TrufflePig
 
 Once the contracts have been deployed, start [TrufflePig](https://github.com/JoinColony/trufflepig):
 
@@ -62,7 +60,7 @@ Once the contracts have been deployed, start [TrufflePig](https://github.com/Joi
 yarn start-trufflepig
 ```
 
-### Seed Network
+## Seed Network
 
 Open a new terminal window and run the seed network script:
 
@@ -70,7 +68,7 @@ Open a new terminal window and run the seed network script:
 yarn seed-network
 ```
 
-### Colony Setup
+## Colony Setup
 
 Once the network has been seeded, run the colony setup script:
 
@@ -78,7 +76,7 @@ Once the network has been seeded, run the colony setup script:
 yarn colony-setup
 ```
 
-### Start Server
+## Start Server
 
 Once your test colony has been set up, start the development server:
 
@@ -86,13 +84,13 @@ Once your test colony has been set up, start the development server:
 yarn start
 ```
 
-### Open Browser
+## Open Browser
 
 Open your browser and check out the example react app:
 
 [localhost:8080](http://localhost:8080)
 
-### Run Tests
+## Run Tests
 
 Open a new terminal window and run the example tests:
 

--- a/docs/_Starters_ColonyStarterReact.md
+++ b/docs/_Starters_ColonyStarterReact.md
@@ -80,7 +80,7 @@ yarn colony-setup
 
 ### Start Server
 
-Once your colony has been set up, start the development server:
+Once your test colony has been set up, start the development server:
 
 ```
 yarn start
@@ -88,7 +88,7 @@ yarn start
 
 ### Open Browser
 
-Open your browser and check out the example react app::
+Open your browser and check out the example react app:
 
 [localhost:8080](http://localhost:8080)
 

--- a/packages/colony-cli/README.md
+++ b/packages/colony-cli/README.md
@@ -53,7 +53,7 @@ colony service deploy-contracts
 Deploy a specific version of the [colonyNetwork](https://github.com/JoinColony/colonyNetwork) smart contracts:
 
 ```
-colony service deploy-contracts --specific develop
+colony service deploy-contracts --specific goerli-rc.1
 ```
 
 Serve truffle contract data with [TrufflePig](https://github.com/JoinColony/trufflepig):

--- a/packages/colony-example-angular/README.md
+++ b/packages/colony-example-angular/README.md
@@ -82,17 +82,9 @@ Open a new terminal window and run the seed network script:
 yarn seed-network
 ```
 
-### Colony Setup
-
-Once the network has been seeded, run the colony setup script:
-
-```
-yarn colony-setup
-```
-
 ### Start Server
 
-Once your colony has been set up, start the development server:
+Once the network has been seeded, start the development server:
 
 ```
 yarn start
@@ -117,5 +109,5 @@ yarn test
 If you do not want to use the default version of the [colonyNetwork](https://github.com/JoinColony/colonyNetwork) smart contracts defined by the [colony-cli](/packages/colony-cli) package, you can update the `"deploy-contracts"` scripts property in your `package.json` file to use a specific version. This can be a branch name, a commit hash, or a version tag.
 
 ```
-"deploy-contracts": "colony service deploy-contracts --specific develop",
+"deploy-contracts": "colony service deploy-contracts --specific goerli-rc.1",
 ```

--- a/packages/colony-example-angular/package.json
+++ b/packages/colony-example-angular/package.json
@@ -23,7 +23,6 @@
     "deploy-contracts": "colony service deploy-contracts",
     "start-trufflepig": "colony service start-trufflepig",
     "seed-network": "colony service seed-network",
-    "colony-setup": "node scripts/colonySetup.js",
     "start": "ng serve",
     "build": "ng build",
     "test": "ng lint && ng test --progress=false"

--- a/packages/colony-example-react/README.md
+++ b/packages/colony-example-react/README.md
@@ -84,7 +84,7 @@ yarn seed-network
 
 ### Start Server
 
-Once your colony has been set up, start the development server:
+Once the network has been seeded, start the development server:
 
 ```
 yarn start
@@ -109,5 +109,5 @@ yarn test
 If you do not want to use the default version of the [colonyNetwork](https://github.com/JoinColony/colonyNetwork) smart contracts defined by the [colony-cli](/packages/colony-cli) package, you can update the `"deploy-contracts"` scripts property in your `package.json` file to use a specific version. This can be a branch name, a commit hash, or a version tag.
 
 ```
-"deploy-contracts": "colony service deploy-contracts --specific develop",
+"deploy-contracts": "colony service deploy-contracts --specific goerli-rc.1",
 ```

--- a/packages/colony-example/README.md
+++ b/packages/colony-example/README.md
@@ -93,5 +93,5 @@ yarn test
 If you do not want to use the default version of the [colonyNetwork](https://github.com/JoinColony/colonyNetwork) smart contracts defined by the [colony-cli](/packages/colony-cli) package, you can update the `"deploy-contracts"` scripts property in your `package.json` file to use a specific version. This can be a branch name, a commit hash, or a version tag.
 
 ```
-"deploy-contracts": "colony service deploy-contracts --specific develop",
+"deploy-contracts": "colony service deploy-contracts --specific goerli-rc.1",
 ```

--- a/packages/colony-starter-angular/README.md
+++ b/packages/colony-starter-angular/README.md
@@ -92,7 +92,7 @@ yarn colony-setup
 
 ### Start Server
 
-Once your colony has been set up, start the development server:
+Once your test colony has been set up, start the development server:
 
 ```
 yarn start
@@ -117,5 +117,5 @@ yarn test
 If you do not want to use the default version of the [colonyNetwork](https://github.com/JoinColony/colonyNetwork) smart contracts defined by the [colony-cli](/packages/colony-cli) package, you can update the `"deploy-contracts"` scripts property in your `package.json` file to use a specific version. This can be a branch name, a commit hash, or a version tag.
 
 ```
-"deploy-contracts": "colony service deploy-contracts --specific develop",
+"deploy-contracts": "colony service deploy-contracts --specific goerli-rc.1",
 ```

--- a/packages/colony-starter-contract/README.md
+++ b/packages/colony-starter-contract/README.md
@@ -95,5 +95,5 @@ yarn truffle [develop/compile/migrate/test]
 If you do not want to use the default version of the [colonyNetwork](https://github.com/JoinColony/colonyNetwork) smart contracts defined by the [colony-cli](/packages/colony-cli) package, you can update the `"deploy-contracts"` scripts property in your `package.json` file to use a specific version. This can be a branch name, a commit hash, or a version tag.
 
 ```
-"deploy-contracts": "colony service deploy-contracts --specific develop",
+"deploy-contracts": "colony service deploy-contracts --specific goerli-rc.1",
 ```

--- a/packages/colony-starter-react/README.md
+++ b/packages/colony-starter-react/README.md
@@ -90,7 +90,7 @@ yarn colony-setup
 
 ### Start Server
 
-Once your colony has been set up, start the development server:
+Once your test colony has been set up, start the development server:
 
 ```
 yarn start
@@ -115,5 +115,5 @@ yarn test
 If you do not want to use the default version of the [colonyNetwork](https://github.com/JoinColony/colonyNetwork) smart contracts defined by the [colony-cli](/packages/colony-cli) package, you can update the `"deploy-contracts"` scripts property in your `package.json` file to use a specific version. This can be a branch name, a commit hash, or a version tag.
 
 ```
-"deploy-contracts": "colony service deploy-contracts --specific develop",
+"deploy-contracts": "colony service deploy-contracts --specific goerli-rc.1",
 ```

--- a/packages/colony-starter/README.md
+++ b/packages/colony-starter/README.md
@@ -93,5 +93,5 @@ yarn test
 If you do not want to use the default version of the [colonyNetwork](https://github.com/JoinColony/colonyNetwork) smart contracts defined by the [colony-cli](/packages/colony-cli) package, you can update the `"deploy-contracts"` scripts property in your `package.json` file to use a specific version. This can be a branch name, a commit hash, or a version tag.
 
 ```
-"deploy-contracts": "colony service deploy-contracts --specific develop",
+"deploy-contracts": "colony service deploy-contracts --specific goerli-rc.1",
 ```


### PR DESCRIPTION
## Description

This pull request removes the `colony-setup` script from `colony-example-angular` and updates the documentation regarding the `colony-setup` script and using the `--specific` service option.

## Related Issues

Closes #109
