### PR TITLE
fixing 'Number can only safely store up to 53 bits' error from amount…

### DIFF
--- a/packages/colony-example-react/src/actions/tokenActions.jsx
+++ b/packages/colony-example-react/src/actions/tokenActions.jsx
@@ -67,7 +67,7 @@ export const getToken = (colonyClient) => ({
     const owner = await colonyClient.tokenClient.contract.owner.call()
 
     // Format total supply
-    const totalSupply = amount.toNumber()
+    const totalSupply = amount.toString()
 
     // return token
     return {


### PR DESCRIPTION
….toNumber call by rendering to string

## Description

Changed line 70 of colonyStarter:packages/colony-example-react/src/actions/tokenActions.jsx to call amount.toString() instead of amount.toNumber() to prevent an 'Number can only safely store up to 53 bits' error.

## Other Changes

_List any minor changes you may have made during development._

## Checklist

Sanity check the change to see if there is a better solution

## Scripts

_List any added/updated scripts._

**Added Scripts**:

**Updated Scripts**:

## Dependencies

_List any added/updated dependencies._

**Added Dependencies**:

**Updated Dependencies**:

## Related Issues

_If the pull request is related to an issue, add a link to the issue here._
